### PR TITLE
Tweak ZAP references

### DIFF
--- a/docs/_posts/2020-05-10-send-traffic-to-burpsuite.md
+++ b/docs/_posts/2020-05-10-send-traffic-to-burpsuite.md
@@ -5,7 +5,7 @@ author_link: https://twitter.com/ggdaniel
 title: "Sending traffic to BurpSuite"
 ---
 
-In the [previous post](https://bbva.github.io/apicheck/2020/05/08/save-navigation-sessions.html) post we talked about how to store navigation traffic in a session file. Now we'll use this file to send it to a proxy, like BurpSuite or OWASP ZAP Proxy
+In the [previous post](https://bbva.github.io/apicheck/2020/05/08/save-navigation-sessions.html) post we talked about how to store navigation traffic in a session file. Now we'll use this file to send it to a proxy, like BurpSuite or ZAP proxy.
 <!--more-->
 
 As part of `APICheck tool set` there's available the [Send-to-proxy](https://bbva.github.io/apicheck/tools/apicheck/send-to-proxy) tool. This tool reads from `stdin` and sends each [APICheck Data Objects](https://bbva.github.io/apicheck/docs/integrating-new-tools#apicheck-data-format) to a proxy.

--- a/docs/_posts/2020-05-11-chaining-burpsuite-and-owasp-zap.md
+++ b/docs/_posts/2020-05-11-chaining-burpsuite-and-owasp-zap.md
@@ -2,19 +2,19 @@
 layout: post
 author: cr0hn
 author_link: https://twitter.com/ggdaniel
-title:  "Chaining BurpSuite and OWASP ZAP"
+title:  "Chaining BurpSuite and ZAP"
 ---
 
-BurpSuite is a nice tool but not Open Source, so not all their features are free. OWASP ZAP is an Open Source alternative but, sadly, it's not so powerful as BurpSuite in some cases. But... why not to use both at the same time? 
+BurpSuite is a nice tool but not Open Source, so not all their features are free. ZAP is an Open Source alternative but, sadly, it's not so powerful as BurpSuite in some cases. But... why not to use both at the same time?
 <!--more-->
 
 Ok, ok, It's true that you can configure BurpSuite to output to another proxy but... why not to use APICheck for that? It's easier and transparent.
 
 Conceptually we will do:
     
-    +-------------------+          +------------------------+        +--------------------------+       +-----------------+
-    |  APICheck Proxy   |--------->| APICheck Send-to-Proxy |-+----->| APICheck Send-to-Proxy   |------>|   OWASP ZAP     |
-    +-------------------+          +------------------------+ |      +--------------------------+       +-----------------+
+    +-------------------+          +------------------------+        +--------------------------+       +---------+
+    |  APICheck Proxy   |--------->| APICheck Send-to-Proxy |-+----->| APICheck Send-to-Proxy   |------>|   ZAP   |
+    +-------------------+          +------------------------+ |      +--------------------------+       +---------+
                                                               |
                                                               |      +--------------------------+
                                                               +----->|    BurpSuite             |
@@ -30,6 +30,6 @@ docker run --rm -it -p 9001:9001 bbvalabs/apicheck-proxy http://127.0.0.1:9000 |
 
 A brief explanation: 
 
-First command starts `APICheck proxy`. Each request you do in your browser will be sent to the first `APICheck send-to-proxy` command. This one, in turn, after sending the received request to the first proxy (BurpSuite), it will send the original request (from Proxy, do you remember?) to the next `APICheck send-to-proxy` command, that sends the same request to the second proxy (OWASP Zap).
+First command starts `APICheck proxy`. Each request you do in your browser will be sent to the first `APICheck send-to-proxy` command. This one, in turn, after sending the received request to the first proxy (BurpSuite), it will send the original request (from Proxy, do you remember?) to the next `APICheck send-to-proxy` command, that sends the same request to the second proxy (ZAP).
 
 Easy, but useful, right?


### PR DESCRIPTION
ZAP left OWASP over a year ago, this just adjust naming.